### PR TITLE
feat(signing-analytics): enhance SignMessage component with explicit signature handling & resilient tracking logic

### DIFF
--- a/frontend/idea-sandbox/components/SignMessage.tsx
+++ b/frontend/idea-sandbox/components/SignMessage.tsx
@@ -25,23 +25,23 @@ Domain: ${window.location.hostname}
 By signing this message, you agree to participate in our educational platform.`;
 
         try {
-            const result = await signMessage({
+            await signMessage({
                 message,
                 account: address // Explicitly pass the account
             });
 
             console.log("📝 Message signed successfully");
-            console.log("✍️ Signature result:", result);
+            console.log("✍️ Signature will be available in hook data");
 
             setHasSigned(true);
-            setSignedData(result || 'signed');
+            setSignedData(signature || 'signed');
 
             // Track the signing event for analytics
             try {
                 const sessionData = {
                     address,
                     chainId,
-                    signature: result,
+                    signature: signature,
                     message,
                     timestamp: new Date().toISOString(),
                     domain: window.location.hostname,
@@ -92,7 +92,7 @@ By signing this message, you agree to participate in our educational platform.`;
                             domain: window.location.hostname,
                             timestamp: Date.now(),
                             method: 'message_signature',
-                            signature_success: !!result
+                            signature_success: !!signature
                         }
                     };
 

--- a/frontend/idea-sandbox/components/SignMessage.tsx
+++ b/frontend/idea-sandbox/components/SignMessage.tsx
@@ -5,9 +5,10 @@ import { useState, useEffect } from 'react';
 
 export default function SignMessage() {
     const { isConnected, address, chainId } = useAccount();
-    const { signMessage, isPending, isSuccess, error } = useSignMessage();
+    const { signMessage, isPending, isSuccess, error, data: signature } = useSignMessage();
     const [hasSigned, setHasSigned] = useState(false);
     const [sessionCreated, setSessionCreated] = useState(false);
+    const [signedData, setSignedData] = useState<string | null>(null);
 
     const handleSignMessage = async () => {
         if (!isConnected || !address) return;
@@ -24,19 +25,23 @@ Domain: ${window.location.hostname}
 By signing this message, you agree to participate in our educational platform.`;
 
         try {
-            const signature = await signMessage({ message });
+            const result = await signMessage({
+                message,
+                account: address // Explicitly pass the account
+            });
 
             console.log("📝 Message signed successfully");
-            console.log("✍️ Signature:", signature);
+            console.log("✍️ Signature result:", result);
 
             setHasSigned(true);
+            setSignedData(result || 'signed');
 
             // Track the signing event for analytics
             try {
                 const sessionData = {
                     address,
                     chainId,
-                    signature,
+                    signature: result,
                     message,
                     timestamp: new Date().toISOString(),
                     domain: window.location.hostname,
@@ -50,20 +55,34 @@ By signing this message, you agree to participate in our educational platform.`;
                     const appKit = (window as any).appkit;
 
                     // Attempt different methods to trigger analytics
-                    if (appKit.track) {
-                        appKit.track('session_created', sessionData);
-                    }
+                    try {
+                        if (appKit.track) {
+                            appKit.track('session_created', sessionData);
+                            console.log("🎯 AppKit track method called");
+                        }
 
-                    if (appKit.analytics) {
-                        appKit.analytics.track('user_signed_message', sessionData);
-                    }
+                        if (appKit.analytics) {
+                            appKit.analytics.track('user_signed_message', sessionData);
+                            console.log("🎯 AppKit analytics track method called");
+                        }
 
-                    setSessionCreated(true);
-                    console.log("🎯 Analytics session creation attempted");
+                        // Try to access the internal analytics instance
+                        if (appKit._analytics) {
+                            appKit._analytics.track('user_authenticated', sessionData);
+                            console.log("🎯 Internal analytics track method called");
+                        }
+
+                        setSessionCreated(true);
+                        console.log("🎯 Analytics session creation attempted");
+                    } catch (trackingError) {
+                        const errorMessage = trackingError instanceof Error ? trackingError.message : String(trackingError);
+                        console.log("📊 AppKit tracking methods not available:", errorMessage);
+                    }
                 }
 
-                // Also try a manual API call to Reown analytics
+                // Manual analytics event to Reown
                 try {
+                    const analyticsEndpoint = 'https://analytics.walletconnect.com/events';
                     const analyticsPayload = {
                         projectId: (window as any).reownProjectId,
                         event: 'user_authenticated',
@@ -72,31 +91,58 @@ By signing this message, you agree to participate in our educational platform.`;
                             chainId: chainId,
                             domain: window.location.hostname,
                             timestamp: Date.now(),
-                            method: 'message_signature'
+                            method: 'message_signature',
+                            signature_success: !!result
                         }
                     };
 
-                    // This might work for manual tracking
-                    console.log("📡 Attempting manual analytics call:", analyticsPayload);
+                    console.log("📡 Attempting manual analytics POST:", analyticsPayload);
+
+                    // Note: This might be blocked by CORS, but worth trying
+                    fetch(analyticsEndpoint, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify(analyticsPayload)
+                    }).then(response => {
+                        console.log("📡 Manual analytics response:", response.status, response.statusText);
+                    }).catch(fetchError => {
+                        const errorMessage = fetchError instanceof Error ? fetchError.message : String(fetchError);
+                        console.log("📡 Manual analytics failed (expected):", errorMessage);
+                    });
 
                 } catch (apiError) {
-                    console.log("📡 Manual API call not available:", apiError);
+                    const errorMessage = apiError instanceof Error ? apiError.message : String(apiError);
+                    console.log("📡 Manual API setup failed:", errorMessage);
                 }
 
             } catch (analyticsError) {
-                console.error("📊 Analytics tracking error:", analyticsError);
+                const errorMessage = analyticsError instanceof Error ? analyticsError.message : String(analyticsError);
+                console.error("📊 Analytics tracking error:", errorMessage);
             }
 
         } catch (signError) {
-            console.error("❌ Failed to sign message:", signError);
+            const errorMessage = signError instanceof Error ? signError.message : String(signError);
+            console.error("❌ Failed to sign message:", errorMessage);
         }
     };
+
+    // Track successful signatures from the hook
+    useEffect(() => {
+        if (isSuccess && signature && !hasSigned) {
+            console.log("🎉 Signature successful from hook:", signature);
+            setHasSigned(true);
+            setSignedData(signature);
+        }
+    }, [isSuccess, signature, hasSigned]);
 
     // Reset state when wallet disconnects
     useEffect(() => {
         if (!isConnected) {
             setHasSigned(false);
             setSessionCreated(false);
+            setSignedData(null);
         }
     }, [isConnected]);
 
@@ -118,8 +164,8 @@ By signing this message, you agree to participate in our educational platform.`;
                 </div>
 
                 {error && (
-                    <div className="text-red-600 text-xs bg-red-50 p-2 rounded">
-                        Error: {error.message}
+                    <div className="text-red-600 text-xs bg-red-50 p-2 rounded max-w-md">
+                        <strong>Error:</strong> {error.message}
                     </div>
                 )}
 
@@ -136,6 +182,11 @@ By signing this message, you agree to participate in our educational platform.`;
                         <div className="text-green-600 text-sm font-medium">
                             ✅ Message signed successfully!
                         </div>
+                        {signedData && (
+                            <div className="text-xs text-gray-600 bg-gray-50 p-2 rounded">
+                                Signature: {signedData.slice(0, 20)}...{signedData.slice(-10)}
+                            </div>
+                        )}
                         {sessionCreated && (
                             <div className="text-blue-600 text-xs">
                                 📊 Analytics session created - check your Reown dashboard!
@@ -152,6 +203,7 @@ By signing this message, you agree to participate in our educational platform.`;
                         onClick={() => {
                             setHasSigned(false);
                             setSessionCreated(false);
+                            setSignedData(null);
                         }}
                         className="text-xs text-gray-500 hover:text-gray-700 underline"
                     >

--- a/frontend/idea-sandbox/package-lock.json
+++ b/frontend/idea-sandbox/package-lock.json
@@ -8,8 +8,8 @@
       "name": "idea-sandbox",
       "version": "0.1.0",
       "dependencies": {
-        "@reown/appkit": "^1.8.6",
-        "@reown/appkit-adapter-wagmi": "^1.8.6",
+        "@reown/appkit": "1.8.6",
+        "@reown/appkit-adapter-wagmi": "1.8.6",
         "@tanstack/react-query": "^5.89.0",
         "next": "15.5.3",
         "react": "19.1.0",
@@ -19,7 +19,6 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
-        "@types/ms": "^2.1.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -189,20 +188,20 @@
       }
     },
     "node_modules/@reown/appkit": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.7.tgz",
-      "integrity": "sha512-lzTDfC15DFd2zF6DfBGXJrNdBohdb7rgMnPF9A/b3O55SkbA+vb3wogWMThSTekEbaJXXUDLl2a+cO7z2/b4Aw==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.6.tgz",
+      "integrity": "sha512-3dXht+l6FtSu7yMC4TlCYySLXVC5fLIfSHvgWExhLMzgSF4f5ZKKO36K2rAyxBHMcJatRJiRUzXMgackQZ7cRg==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-controllers": "1.8.7",
-        "@reown/appkit-pay": "1.8.7",
-        "@reown/appkit-polyfills": "1.8.7",
-        "@reown/appkit-scaffold-ui": "1.8.7",
-        "@reown/appkit-ui": "1.8.7",
-        "@reown/appkit-utils": "1.8.7",
-        "@reown/appkit-wallet": "1.8.7",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-controllers": "1.8.6",
+        "@reown/appkit-pay": "1.8.6",
+        "@reown/appkit-polyfills": "1.8.6",
+        "@reown/appkit-scaffold-ui": "1.8.6",
+        "@reown/appkit-ui": "1.8.6",
+        "@reown/appkit-utils": "1.8.6",
+        "@reown/appkit-wallet": "1.8.6",
         "@walletconnect/universal-provider": "2.21.7",
         "bs58": "6.0.0",
         "semver": "7.7.2",
@@ -214,18 +213,18 @@
       }
     },
     "node_modules/@reown/appkit-adapter-wagmi": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.8.7.tgz",
-      "integrity": "sha512-gCG1e7n9IMaqP6EWM9dYZLUaec5FCN/WxzBQD0iNGrYs7OFpOhsMMJm/DNtZ6xkdOJiSVBVu3JG2aXZuKsFnSQ==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.8.6.tgz",
+      "integrity": "sha512-amAw0e5Se81At2LpXRMoPvglC0fjsEYkasai8HzVN9hYpEJq45DWow+gUdxg24dEujRjcn6aLuA7yVSu3cYX5A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit": "1.8.7",
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-controllers": "1.8.7",
-        "@reown/appkit-polyfills": "1.8.7",
-        "@reown/appkit-scaffold-ui": "1.8.7",
-        "@reown/appkit-utils": "1.8.7",
-        "@reown/appkit-wallet": "1.8.7",
+        "@reown/appkit": "1.8.6",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-controllers": "1.8.6",
+        "@reown/appkit-polyfills": "1.8.6",
+        "@reown/appkit-scaffold-ui": "1.8.6",
+        "@reown/appkit-utils": "1.8.6",
+        "@reown/appkit-wallet": "1.8.6",
         "@walletconnect/universal-provider": "2.21.7",
         "valtio": "2.1.7"
       },
@@ -239,9 +238,9 @@
       }
     },
     "node_modules/@reown/appkit-common": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.7.tgz",
-      "integrity": "sha512-OJPAKBU8XETPXanNVWWI9nb08r16+rySU/O5MHiGOMMTQ1CiWyLTD63dVvSeS5ECGW27jAhg4X6yPyNuGKnQ6w==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.6.tgz",
+      "integrity": "sha512-A4U/80u+ELqWYKDF/OWXHa4+O2BMILvZSyuXEt2NrNzozrMfUB3yq12jXGkqJHkiv7E8smo0khxneX3cSCGuaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "big.js": "6.2.2",
@@ -269,28 +268,28 @@
       "license": "MIT"
     },
     "node_modules/@reown/appkit-controllers": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.7.tgz",
-      "integrity": "sha512-UZ5XcO38KLfza6ZeNxaghq2CfNuIz05sFDW31l3UJR78p8rNDYtXSbWoanj8lELZhKilwY7whFyX+7EIi+P5mA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.6.tgz",
+      "integrity": "sha512-+ftwSvT8VcMjCJXwf7IfOAp/5lJpJka7Y1nps+iiAE1J1+20BD3yOQ50TUhyCczIegutbuDINlVPUnYufe3a1A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-wallet": "1.8.7",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-wallet": "1.8.6",
         "@walletconnect/universal-provider": "2.21.7",
         "valtio": "2.1.7",
         "viem": ">=2.37.2"
       }
     },
     "node_modules/@reown/appkit-pay": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.7.tgz",
-      "integrity": "sha512-agKrLhiK0ahLOMuaR9njq0+855AZ6IkbYSFH+/jsfq+g3/KJaoO6FBXLENlZo053dOelN+bWK9mggeHTL9r0Sg==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.6.tgz",
+      "integrity": "sha512-fU80ENaKBknYctDnN7RZYLjyW2B29ZGfwIy5x7sEDny9WBlMVAHgG1dAKEKlU6WkYEM5aTaUe1tl4NhhwPpVVg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-controllers": "1.8.7",
-        "@reown/appkit-ui": "1.8.7",
-        "@reown/appkit-utils": "1.8.7",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-controllers": "1.8.6",
+        "@reown/appkit-ui": "1.8.6",
+        "@reown/appkit-utils": "1.8.6",
         "lit": "3.3.0",
         "valtio": "2.1.7"
       }
@@ -348,9 +347,9 @@
       }
     },
     "node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.7.tgz",
-      "integrity": "sha512-ZzPFM/mBo676rAJsjVoWbOKOwQFvzoHnPY1Gm0omXk3RM11CP+KhVnGQDy+fN5ZXZ1VSUQSDsjN7sofIlvytXw==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.6.tgz",
+      "integrity": "sha512-aoBkQSHCZvoLgdHfZfeOLswrYHIPGhhknRMUk8UHDhQsoALCvIEYrenhgIDZUSfkJC//z+4OfQO/yVq3g3vecA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "buffer": "6.0.3"
@@ -421,16 +420,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.7.tgz",
-      "integrity": "sha512-gx3uogqpw9k6AJ5smowdrGdFg7WjbYtnOiDw/jwDi9zmEd8T0BDmCl6xX9QN0s26943VX2mh2bLVWpX6Agk47A==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.6.tgz",
+      "integrity": "sha512-H4NCFBv5fII49pEdJYaIXeujpwJ3WLVAmyaC4i+BxCpDZ8Us8TtNhYoH2ziEqJvsHwC6BhZ54CAlTOszjiww1w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-controllers": "1.8.7",
-        "@reown/appkit-ui": "1.8.7",
-        "@reown/appkit-utils": "1.8.7",
-        "@reown/appkit-wallet": "1.8.7",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-controllers": "1.8.6",
+        "@reown/appkit-ui": "1.8.6",
+        "@reown/appkit-utils": "1.8.6",
+        "@reown/appkit-wallet": "1.8.6",
         "lit": "3.3.0"
       }
     },
@@ -487,15 +486,15 @@
       }
     },
     "node_modules/@reown/appkit-ui": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.7.tgz",
-      "integrity": "sha512-VBTFA0SiPBq9HOfuOXNiOtNmMeCCv84HfhEILglNWtk+RiGM56mxQoCQJ1t/dQb/xGqwpXo+24czbliDUyZK6Q==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.6.tgz",
+      "integrity": "sha512-c2/UYGRoI/nayqiPp+nxxw7Wohdzl7Z1J14/p/HHPYyl1/qtV0DaHZW8ZA3NtxfmFGny7eE4fRz5YXRwNDuzAw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@phosphor-icons/webcomponents": "2.1.5",
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-controllers": "1.8.7",
-        "@reown/appkit-wallet": "1.8.7",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-controllers": "1.8.6",
+        "@reown/appkit-wallet": "1.8.6",
         "lit": "3.3.0",
         "qrcode": "1.5.3"
       }
@@ -874,15 +873,15 @@
       }
     },
     "node_modules/@reown/appkit-utils": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.7.tgz",
-      "integrity": "sha512-OW5Y8GDNZ2OGeLepnQuppf1b+2rjEPF/e416yOORDG4Ha2jlNOEWPbPhaurvxMRDdER4w/2X59Ekc+R+PzEuUw==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.6.tgz",
+      "integrity": "sha512-MpnCsQEsDh3SMU0+0Vsn5aX/2dfO+oNTvwPz4hvb35sHqR1NoP/CO0IzCApLjc84TXqbX5giavzgME5s3QL3Jw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-controllers": "1.8.7",
-        "@reown/appkit-polyfills": "1.8.7",
-        "@reown/appkit-wallet": "1.8.7",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-controllers": "1.8.6",
+        "@reown/appkit-polyfills": "1.8.6",
+        "@reown/appkit-wallet": "1.8.6",
         "@wallet-standard/wallet": "1.1.0",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/universal-provider": "2.21.7",
@@ -1156,13 +1155,13 @@
       "license": "ISC"
     },
     "node_modules/@reown/appkit-wallet": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.7.tgz",
-      "integrity": "sha512-ExvQ4u68W0BuM9i+tptH6k/DMInM+MWeLexB35WJRnAa9mQAT1EZbFhFA5hOm8YiEmWrG6nBLMv5/zRChVf9hw==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.6.tgz",
+      "integrity": "sha512-m0Um+PLeWEHsW8saBWdjkROFs5DRI++SWb+NL+k4Ys2+PfhH9adAbV8o6SJEUzG4XqWhQsS5QrpNo4ZJIfyu5g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.7",
-        "@reown/appkit-polyfills": "1.8.7",
+        "@reown/appkit-common": "1.8.6",
+        "@reown/appkit-polyfills": "1.8.6",
         "@walletconnect/logger": "2.1.2",
         "zod": "3.22.4"
       }
@@ -2181,12 +2180,7 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
-    },
+    "node_modules/@types/ms": {},
     "node_modules/@types/node": {
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",

--- a/frontend/idea-sandbox/package-lock.json
+++ b/frontend/idea-sandbox/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/ms": "^2.1.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2180,7 +2181,12 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@types/ms": {},
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",

--- a/frontend/idea-sandbox/package.json
+++ b/frontend/idea-sandbox/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@reown/appkit": "^1.8.6",
-    "@reown/appkit-adapter-wagmi": "^1.8.6",
+    "@reown/appkit": "1.8.6",
+    "@reown/appkit-adapter-wagmi": "1.8.6",
     "@tanstack/react-query": "^5.89.0",
     "next": "15.5.3",
     "react": "19.1.0",
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/ms": "^2.1.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -27,6 +26,9 @@
     "typescript": "^5"
   },
   "overrides": {
-    "@reown/appkit": "$@reown/appkit"
+    "@reown/appkit": "1.8.6",
+    "@walletconnect/ethereum-provider": {
+      "@reown/appkit": "1.8.6"
+    }
   }
 }

--- a/frontend/idea-sandbox/package.json
+++ b/frontend/idea-sandbox/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/ms": "^2.1.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
# Description
This PR improves the **signature flow and analytics reliability** within `SignMessage.tsx`, while tightening dependency configurations.

---

## ✅ Key Improvements

| Area | Change | Purpose |
|------|--------|---------|
| **Signature Handling** | Now explicitly passes `{ account: address }` to `signMessage`, captures return value, and syncs with `useSignMessage` hook output | Ensures **consistent signature capture across wallet providers** |
| **New State Tracking** | Introduced `signedData` state alongside `hasSigned` and `sessionCreated` | Allows UI display & debug replay of captured signatures |
| **AppKit / Analytics Tracking** | Added layered tracking attempts (`track`, `analytics.track`, `_analytics.track`) with proper try/catch logging | Improves **session creation success rate** across AppKit versions |
| **Manual Analytics POST** | Added optional `fetch` call to `analytics.walletconnect.com/events` with fallback guards | Enables **direct analytics injection** even if SDK fails |
| **Improved Error Handling** | All analytics & signature failures are now fully stringified with safe guards | Prevents silent errors and malformed console traces |
| **UX Enhancements** | Error block now max-width constrained, signature preview is truncated and styled for readability | Better **debug ergonomics** for both users & testers |
| **Dependency Updates** | Locked `@reown/appkit` and `@reown/appkit-adapter-wagmi` to `1.8.6` and updated `overrides` structure | Prevents accidental shifts due to semver drift |

---

## 🧠 Result

The signing flow is now:

